### PR TITLE
Fix parse_repo_config with regards to repository priority

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -394,7 +394,7 @@ parse_repo_config() {
 	local flat_config=$(echo "${repo_config}" | gawk '
 		function push(arr, idx, ele) {
 			if (idx in arr)
-				arr[idx][length(arr) + 1] = ele
+				arr[idx][length(arr[idx]) + 1] = ele
 			else
 				arr[idx][0] = ele
 		}


### PR DESCRIPTION
Before this patch, the repository config would be inserted into a more or less
 place for the respective priority, resulting in a non-contiguous array, which
 would no longer be fully enumerated by an awk for loop.  Hence the config of
 repositories with the same priority would be omitted for all but the first few
 entries.

Signed-off-by: Dennis Schridde <devurandom@gmx.net>
  